### PR TITLE
Fix state not being shared with "beforeXXX" and "afterXXX" events

### DIFF
--- a/packages/core/database/lib/entity-manager.js
+++ b/packages/core/database/lib/entity-manager.js
@@ -113,33 +113,36 @@ const createEntityManager = db => {
 
   return {
     async findOne(uid, params) {
-      await db.lifecycles.run('beforeFindOne', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeFindOne', uid, event);
 
       const result = await this.createQueryBuilder(uid)
         .init(params)
         .first()
         .execute();
 
-      await db.lifecycles.run('afterFindOne', uid, { params, result });
+      await db.lifecycles.run('afterFindOne', uid, { ...event, result });
 
       return result;
     },
 
     // should we name it findOne because people are used to it ?
     async findMany(uid, params) {
-      await db.lifecycles.run('beforeFindMany', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeFindMany', uid, event);
 
       const result = await this.createQueryBuilder(uid)
         .init(params)
         .execute();
 
-      await db.lifecycles.run('afterFindMany', uid, { params, result });
+      await db.lifecycles.run('afterFindMany', uid, { ...event, result });
 
       return result;
     },
 
     async count(uid, params = {}) {
-      await db.lifecycles.run('beforeCount', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeCount', uid, event);
 
       const res = await this.createQueryBuilder(uid)
         .init(_.pick(['_q', 'where', 'filters'], params))
@@ -149,13 +152,14 @@ const createEntityManager = db => {
 
       const result = Number(res.count);
 
-      await db.lifecycles.run('afterCount', uid, { params, result });
+      await db.lifecycles.run('afterCount', uid, { ...event, result });
 
       return result;
     },
 
     async create(uid, params = {}) {
-      await db.lifecycles.run('beforeCreate', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeCreate', uid, event);
 
       const metadata = db.metadata.get(uid);
       const { data } = params;
@@ -180,14 +184,15 @@ const createEntityManager = db => {
         populate: params.populate,
       });
 
-      await db.lifecycles.run('afterCreate', uid, { params, result });
+      await db.lifecycles.run('afterCreate', uid, { ...event, result });
 
       return result;
     },
 
     // TODO: where do we handle relation processing for many queries ?
     async createMany(uid, params = {}) {
-      await db.lifecycles.run('beforeCreateMany', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeCreateMany', uid, event);
 
       const metadata = db.metadata.get(uid);
       const { data } = params;
@@ -208,13 +213,14 @@ const createEntityManager = db => {
 
       const result = { count: data.length };
 
-      await db.lifecycles.run('afterCreateMany', uid, { params, result });
+      await db.lifecycles.run('afterCreateMany', uid, { ...event, result });
 
       return result;
     },
 
     async update(uid, params = {}) {
-      await db.lifecycles.run('beforeUpdate', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeUpdate', uid, event);
 
       const metadata = db.metadata.get(uid);
       const { where, data } = params;
@@ -257,14 +263,15 @@ const createEntityManager = db => {
         populate: params.populate,
       });
 
-      await db.lifecycles.run('afterUpdate', uid, { params, result });
+      await db.lifecycles.run('afterUpdate', uid, { ...event, result });
 
       return result;
     },
 
     // TODO: where do we handle relation processing for many queries ?
     async updateMany(uid, params = {}) {
-      await db.lifecycles.run('beforeUpdateMany', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeUpdateMany', uid, event);
 
       const metadata = db.metadata.get(uid);
       const { where, data } = params;
@@ -282,13 +289,14 @@ const createEntityManager = db => {
 
       const result = { count: updatedRows };
 
-      await db.lifecycles.run('afterUpdateMany', uid, { params, result });
+      await db.lifecycles.run('afterUpdateMany', uid, { ...event, result });
 
       return result;
     },
 
     async delete(uid, params = {}) {
-      await db.lifecycles.run('beforeDelete', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeDelete', uid, event);
 
       const { where, select, populate } = params;
 
@@ -316,14 +324,15 @@ const createEntityManager = db => {
 
       await this.deleteRelations(uid, id);
 
-      await db.lifecycles.run('afterDelete', uid, { params, result: entity });
+      await db.lifecycles.run('afterDelete', uid, { ...event, result: entity });
 
       return entity;
     },
 
     // TODO: where do we handle relation processing for many queries ?
     async deleteMany(uid, params = {}) {
-      await db.lifecycles.run('beforeDeleteMany', uid, { params });
+      const event = { params };
+      await db.lifecycles.run('beforeDeleteMany', uid, event);
 
       const { where } = params;
 
@@ -334,7 +343,7 @@ const createEntityManager = db => {
 
       const result = { count: deletedRows };
 
-      await db.lifecycles.run('afterDelete', uid, { params, result });
+      await db.lifecycles.run('afterDelete', uid, { ...event, result });
 
       return result;
     },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fix state not being shared between "beforeXXX" and "afterXXX" events, as described in the documentation here:
https://docs.strapi.io/developer-docs/latest/development/backend-customization/models.html#hook-event-object

### Why is it needed?

The feature is described in the documentation. Sharing state is useful to update external resources for instance.

### How to test it?

* Create a content-type from the UI
* Create `lifecycles.js` file in `src/api/<type>/content-types/<type>`
* Minimal test case code
```js

module.exports = {
    async beforeUpdate(event) {
        event.state = 'hello world';
        return event;
    },

    async afterUpdate(event) {
        // event.state is undefined before this fix, but it should be set to 'hello world'
        console.log(event.state);
    },
};
```

### Related issue(s)/PR(s)

None
